### PR TITLE
Fix database file path when the app is not in root

### DIFF
--- a/php/db.php
+++ b/php/db.php
@@ -2,7 +2,7 @@
 
 // Database location
 include('version.php');
-$docRoot = $_SERVER['DOCUMENT_ROOT'];
+$docRoot = str_replace("\\", "/", realpath(dirname(__FILE__) . '/..'));
 //define('DBFILE', $docRoot . '/data/ownmapp_v' . $VERSION . '.sqlite3');
 define('DBFILE', $docRoot . '/data/ownmapp.sqlite3');
 


### PR DESCRIPTION
It didn't work when I had the application in a folder below the root. I tried to make a solution without having to use $_SERVER['DOCUMENT_ROOT'] since people say it is unreliable cross platform-wise.